### PR TITLE
Adding ci-operator yaml file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.18


### PR DESCRIPTION
Getting error in pr trying to add prow-scripts: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47737/rehearse-47737-periodic-ci-redhat-chaos-krkn-hub-main-4.15-nightly-krkn-hub-tests-415/1747649907314921472

```
ERRO[2024-01-17T16:00:51Z] Some steps failed:                           
ERRO[2024-01-17T16:00:51Z] 
  * failed to generate steps from config: failed to get steps from configuration: failed to read buildRootImageStream from repository: failed to read .ci-operator.yaml file: open ./.ci-operator.yaml: no such file or directory 
INFO[2024-01-17T16:00:51Z] Reporting job state 'failed' with reason 'defaulting_config' 
```