### PR TITLE
need extra dash - power outage

### DIFF
--- a/power-outage/prow_run.sh
+++ b/power-outage/prow_run.sh
@@ -18,7 +18,7 @@ oc version
 
 # Substitute config with environment vars defined
 envsubst < power-outages/shutdown_scenario.yaml.template > /tmp/power_outage_scenario.yaml
-export SCENARIO_FILE=/tmp/power_outage_scenario.yaml
+export SCENARIO_FILE="- /tmp/power_outage_scenario.yaml"
 envsubst < config.yaml.template > /tmp/power_outage_config.yaml
 
 # Run Kraken


### PR DESCRIPTION
Failure in prow run 

```
2024-02-12 21:36:51,252 [INFO] Successfully injected cluster_shut_down scenario!
2024-02-12 21:36:51,255 [INFO] Waiting for the specified duration: 100
/bin/sh: t: command not found
2024-02-12 21:38:31,422 [ERROR] Failed to run t, error: Command 't' returned non-zero exit status 127.
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"k8s.io/test-infra/prow/entrypoint/run.go:84","func":"k8s.io/test-infra/prow/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2024-02-12T21:38:32Z"}
error: failed to execute wrapped command: exit status 1 
INFO[2024-02-12T21:38:33Z] Step krkn-hub-cloud-api-tests-redhat-chaos-power-outage failed after 22m47s. 
INFO[2024-02-12T21:38:33Z] Step phase test failed after 26m43s.  
```