### PR TITLE
Set correct loc of scenario file

### DIFF
--- a/zone-outages/prow_run.sh
+++ b/zone-outages/prow_run.sh
@@ -20,7 +20,7 @@ oc version
 envsubst < zone-outages/zone_outage_scenario.yaml.template > /tmp/zone_outage.yaml
 envsubst < config.yaml.template > /tmp/zone_config.yaml
 
-export SCENARIO_FILE=$krkn_loc/scenarios/zone_outage.yaml
+export SCENARIO_FILE=/tmp/zone_outage.yaml
 
 # Run Kraken
 cat /tmp/zone_outage.yaml


### PR DESCRIPTION
Wrong location of scenario file

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52576/rehearse-52576-periodic-ci-redhat-chaos-prow-scripts-main-4.16-nightly-krkn-hub-zone-tests/1795946937350885376
```
2024-05-29 23:44:06,465 [INFO] Executing scenarios for iteration 0
2024-05-29 23:44:06,465 [INFO] Inject zone outages
Traceback (most recent call last):
  File "/root/kraken/run_kraken.py", line 504, in <module>
    main(options.cfg)
  File "/root/kraken/run_kraken.py", line 331, in main
    failed_post_scenarios, scenario_telemetries = zone_outages.run(scenarios_list, config, wait_duration, telemetry_k8s)
  File "/root/kraken/kraken/zone_outage/actions.py", line 23, in run
    telemetry.set_parameters_base64(scenario_telemetry, zone_outage_config)
  File "/usr/local/lib/python3.9/site-packages/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py", line 501, in set_parameters_base64
    raise Exception(
Exception: telemetry : scenario file not found scenarios/zone_outage.yaml 
```