### PR TITLE
Make /home/krkn writable and executable by all users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN git clone https://github.com/krkn-chaos/krkn-hub.git /home/krkn/krkn-hub
 ADD . /home/krkn/krkn-hub
 
 USER root
-RUN chmod +x /home/krkn/krkn-hub/*/prow_run.sh
+RUN chown -R krkn:krkn /home/krkn && chmod -R 777 /home/krkn
+
 
 USER krkn
 ENV PYTHONPATH=/home/krkn/krkn-hub/packages:$PYTHONPATH PYTHONUNBUFFERED=1


### PR DESCRIPTION
The user set in the container is krkn but root is the user executing the scripts when running in prow CI.
```
 drwxr-xr-x. 2 root root  25 Jul 10 15:05 .
drwxr-xr-x. 1 krkn krkn  99 Jul 10 15:05 ..
-rwxr-xr-x. 1 root root 792 Jul 10 15:05 prow_run.sh 
 ./memory-hog/prow_run.sh: line 21: /home/krkn/kraken/scenarios/arcaflow/memory-hog/input.yaml.template: Permission denied 
```