### PR TITLE
Run hog scenarios from the kraken dir

### DIFF
--- a/cpu-hog/prow_run.sh
+++ b/cpu-hog/prow_run.sh
@@ -29,4 +29,5 @@ envsubst < config.yaml.template > $krkn_loc/cpu_hog_config.yaml
 # Run Kraken
 cat $krkn_loc/cpu_hog_config.yaml
 cat $SCENARIO_FOLDER/input.yaml
-python3.9 $krkn_loc/run_kraken.py --config=$krkn_loc/cpu_hog_config.yaml -o /tmp/report.out
+cd $krkn_loc
+python3.9 run_kraken.py --config=cpu_hog_config.yaml -o /tmp/report.out

--- a/io-hog/prow_run.sh
+++ b/io-hog/prow_run.sh
@@ -29,5 +29,6 @@ envsubst < config.yaml.template > $krkn_loc/io_hog_config.yaml
 # Run Kraken
 cat $krkn_loc/io_hog_config.yaml
 cat $SCENARIO_FOLDER/input.yaml
-python3.9 $krkn_loc/run_kraken.py --config=$krkn_loc/io_hog_config.yaml -o /tmp/report.out
+cd $krkn_loc
+python3.9 run_kraken.py --config=io_hog_config.yaml -o /tmp/report.out
 

--- a/memory-hog/prow_run.sh
+++ b/memory-hog/prow_run.sh
@@ -29,5 +29,6 @@ envsubst < config.yaml.template > $krkn_loc/memory_hog_config.yaml
 # Run Kraken
 cat $krkn_loc/memory_hog_config.yaml
 cat $SCENARIO_FOLDER/input.yaml
-python3.9 $krkn_loc/run_kraken.py --config=$krkn_loc/memory_hog_config.yaml -o /tmp/report.out
+cd $krkn_loc
+python3.9 run_kraken.py --config=memory_hog_config.yaml -o /tmp/report.out
 


### PR DESCRIPTION
This fixes the following issue:
```
   File "/home/krkn/kraken/kraken/arcaflow_plugin/arcaflow_plugin.py", line 44, in build_args
    raise Exception(
Exception: context folder for arcaflow workflow not found: /home/krkn/krkn-hub//home/krkn/kraken/scenarios/arcaflow/memory-hog
```