### PR TITLE
Use relative path for hog scenarios

### DIFF
--- a/cpu-hog/prow_run.sh
+++ b/cpu-hog/prow_run.sh
@@ -23,7 +23,7 @@ setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 
 # Substitute config with environment vars defined
-export SCENARIO_FILE="$SCENARIO_FOLDER/input.yaml"
+export SCENARIO_FILE="scenarios/arcaflow/cpu-hog/input.yaml"
 envsubst < config.yaml.template > $krkn_loc/cpu_hog_config.yaml
 
 # Run Kraken

--- a/io-hog/prow_run.sh
+++ b/io-hog/prow_run.sh
@@ -23,7 +23,7 @@ setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 
 # Substitute config with environment vars defined
-export SCENARIO_FILE="$SCENARIO_FOLDER/input.yaml"
+export SCENARIO_FILE="scenarios/arcaflow/io-hog/input.yaml"
 envsubst < config.yaml.template > $krkn_loc/io_hog_config.yaml
 
 # Run Kraken

--- a/memory-hog/prow_run.sh
+++ b/memory-hog/prow_run.sh
@@ -23,7 +23,7 @@ setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 
 # Substitute config with environment vars defined
-export SCENARIO_FILE="$SCENARIO_FOLDER/input.yaml"
+export SCENARIO_FILE="scenarios/arcaflow/memory-hog/input.yaml"
 envsubst < config.yaml.template > $krkn_loc/memory_hog_config.yaml
 
 # Run Kraken


### PR DESCRIPTION
This avoids hitting issues such as
```
  File "/home/krkn/kraken/kraken/arcaflow_plugin/arcaflow_plugin.py", line 44, in build_args
    raise Exception(
Exception: context folder for arcaflow workflow not found: /home/krkn/kraken//home/krkn/kraken/scenarios/arcaflow/memory-hog
```