### PR TITLE
Do not envsubst before arca setup for hog scenarios

### DIFF
--- a/cpu-hog/prow_run.sh
+++ b/cpu-hog/prow_run.sh
@@ -18,7 +18,7 @@ oc version
 source node-cpu-hog/env.sh
 source common_run.sh
 
-envsubst < node-cpu-hog/input.yaml.template> $SCENARIO_FOLDER/input.yaml.template
+cp node-cpu-hog/input.yaml.template $SCENARIO_FOLDER/input.yaml.template
 setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 

--- a/io-hog/prow_run.sh
+++ b/io-hog/prow_run.sh
@@ -18,7 +18,7 @@ oc version
 source node-io-hog/env.sh
 source common_run.sh
 
-envsubst < node-io-hog/input.yaml.template> $SCENARIO_FOLDER/input.yaml
+cp node-io-hog/input.yaml.template $SCENARIO_FOLDER/input.yaml.template
 setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 

--- a/memory-hog/prow_run.sh
+++ b/memory-hog/prow_run.sh
@@ -18,7 +18,7 @@ oc version
 source node-memory-hog/env.sh
 source common_run.sh
 
-envsubst < node-memory-hog/input.yaml.template> $SCENARIO_FOLDER/input.yaml.template
+cp node-memory-hog/input.yaml.template $SCENARIO_FOLDER/input.yaml.template
 setup_arcaflow_env "$SCENARIO_FOLDER"
 checks
 


### PR DESCRIPTION
This will replace the input template before arca setup where the node selector is set.