### PR TITLE
Ibm node

### DIFF
--- a/node-disruptions/prow_run.sh
+++ b/node-disruptions/prow_run.sh
@@ -26,8 +26,10 @@ if [[ "$CLOUD_TYPE" == "vmware" || "$CLOUD_TYPE" == "ibmcloud" ]]; then
   export ACTION=${ACTION:="$CLOUD_TYPE-node-reboot"}
 else
   envsubst < node-scenarios/node_scenario.yaml.template > /tmp/node_scenario.yaml
+  export SCENARIO_TYPE=node_scenarios
+
 fi
-export SCENARIO_TYPE=node_scenarios
+
 export SCENARIO_FILE=/tmp/node_scenario.yaml
 envsubst < config.yaml.template > /tmp/node_scenario_config.yaml
 


### PR DESCRIPTION
For Ibm node scenario, scenario type is being over written 

```
kraken:
    distribution: openshift                                # Distribution can be kubernetes or openshift
    kubeconfig_path: /tmp/config                   # Path to kubeconfig
    exit_on_failure: False                                 # Exit when a post action scenario fails
    port: 8081
    publish_kraken_status: False
    signal_state: RUN                            # Will wait for the RUN signal when set to PAUSE before running the scenarios
    signal_address: 0.0.0.0                        # Signal listening address
    chaos_scenarios:                                       # List of policies/chaos scenarios to load
        - node_scenarios:                                  # List of chaos time scenarios to load
```