### PR TITLE
Adding no check setup

### DIFF
--- a/syn-flood/prow_run.sh
+++ b/syn-flood/prow_run.sh
@@ -19,8 +19,6 @@ krkn_loc=/home/krkn/kraken
 # Substitute config with environment vars defined
 envsubst < config.yaml.template > /tmp/syn_flood_config.yaml
 
-config_setup
-
 # Run Kraken
 cat /tmp/syn_flood_config.yaml
 python3.9 $krkn_loc/run_kraken.py --config=/tmp/syn_flood_config.yaml -o /tmp/report.out 2>&1


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/59426/rehearse-59426-pull-ci-redhat-chaos-prow-scripts-main-4.18-nightly-krkn-hub-syn-flood/1864345912566878208

```
+ config_setup
./syn-flood/prow_run.sh: line 22: config_setup: command not found
{"component":"entrypoint","error":"wrapped process failed: exit status 127","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2024-12-04T18:04:45Z"}
```