### PR TITLE
Deprecate config_setup step for hog scenarios

### DIFF
--- a/cpu-hog/prow_run.sh
+++ b/cpu-hog/prow_run.sh
@@ -20,7 +20,6 @@ source node-cpu-hog/env.sh
 source common_run.sh
 
 cp node-cpu-hog/cpu-hog.yml.template $sub_scenario_folder/cpu-hog.yml
-config_setup
 checks
 
 # Substitute config with environment vars defined

--- a/io-hog/prow_run.sh
+++ b/io-hog/prow_run.sh
@@ -28,7 +28,7 @@ export SCENARIO_FILE="$sub_scenario_folder/io-hog.yml"
 envsubst < config.yaml.template > $krkn_loc/io_hog_config.yaml
 
 checks
-config_setup
+
 # Run Kraken
 
 cd $krkn_loc

--- a/memory-hog/prow_run.sh
+++ b/memory-hog/prow_run.sh
@@ -28,7 +28,6 @@ export SCENARIO_FILE="$sub_scenario_folder/memory-hog.yml"
 envsubst < config.yaml.template > $krkn_loc/config/mem-config.yaml
 
 checks
-config_setup
 
 # Run Kraken
 cd $krkn_loc


### PR DESCRIPTION
The step is no longer in use as kube-burner integration is now deprecated.